### PR TITLE
Return loqusdb version info from / endpoint

### DIFF
--- a/loqusdbapi/main.py
+++ b/loqusdbapi/main.py
@@ -74,7 +74,7 @@ def database(uri: str = None, db_name: str = None) -> MongoAdapter:
 
 @app.get("/")
 def read_root():
-    return {"message": "Welcome to the loqusdbapi", "loqus_version": loqusdb.__version__}
+    return {"message": "Welcome to the loqusdbapi", "loqusdb_version": loqusdb.__version__}
 
 
 @app.get("/variants/{variant_id}", response_model=Variant)


### PR DESCRIPTION
Fix #2. This is just a suggestion and I see that my version of Black is different from yours, so feel free to edit!

Returns the loqusdb version installed together with welcome message in / endpoint.  

**How to prepare for test**:
- [x] Start app with `uvicorn loqusdbapi.main:app --reload`

### How to test:
- [x] curl -X GET "http://127.0.0.1:8000/" from another terminal

### Expected outcome:
- Response should contain the version of loqusdb module installed in loqusdbapi

### Review:
- [x] Code approved by MM
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
