### PR TITLE
Endpoint returning number of cases with SNVs and SVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,20 @@
 
 Small REST api to use with [loqusdb][loqusdb].
 
-Currently only supports get requests for **variant**, **structural_variant** and **case**.
+Currently only supports get requests for **variant**, **structural_variant**, **case** and **cases**.
 
 # Usage
 
 ## Running local installation
 
-For all of the use cases below, do 
+For all of the use cases below, do
 
 1. `git clone https://github.com/Clinical-Genomics/loqusdbapi`
 1. `cd loqusdbapi`
 
 For all these examples you need to make sure that mongodb is running.
-If `mongod` is listening to another port than `27017`, if it is on another server than localhost, if it needs password 
-etc, use the environmental variable `URI`. 
+If `mongod` is listening to another port than `27017`, if it is on another server than localhost, if it needs password
+etc, use the environmental variable `URI`.
 If only testing the app use the `docker-compose`-solution below.
 More information about setup should be fairly easy to understand by looking at `docker-compose.yml`.
 

--- a/loqusdbapi/main.py
+++ b/loqusdbapi/main.py
@@ -51,6 +51,11 @@ class StructuralVariant(BaseVariant):
     pos_right: int
 
 
+class Cases(BaseModel):
+    nr_cases_snvs: Optional[int]
+    nr_cases_svs: Optional[int]
+
+
 class Case(BaseModel):
     case_id: str
     nr_variants: Optional[int]
@@ -74,7 +79,10 @@ def database(uri: str = None, db_name: str = None) -> MongoAdapter:
 
 @app.get("/")
 def read_root():
-    return {"message": "Welcome to the loqusdbapi", "loqusdb_version": loqusdb.__version__}
+    return {
+        "message": "Welcome to the loqusdbapi",
+        "loqusdb_version": loqusdb.__version__,
+    }
 
 
 @app.get("/variants/{variant_id}", response_model=Variant)
@@ -111,6 +119,17 @@ def read_sv(
     structural_variant["nr_cases"] = db.nr_cases(snv_cases=False, sv_cases=True)
 
     return structural_variant
+
+
+@app.get("/cases", response_model=Cases)
+def read_cases(db: MongoAdapter = Depends(database)):
+    nr_cases_snvs = db.nr_cases(snv_cases=True, sv_cases=False)
+    nr_cases_svs = db.nr_cases(snv_cases=False, sv_cases=True)
+
+    return dict(
+        nr_cases_snvs=nr_cases_snvs,
+        nr_cases_svs=nr_cases_svs,
+    )
 
 
 @app.get("/cases/{case_id}", response_model=Case)


### PR DESCRIPTION
### This PR adds | fixes:
- Adds the `cases` endpoint, which returns the number of cases with SNVs and SVs. 

Added this because it's required in scout, specifically [here](https://github.com/Clinical-Genomics/scout/blob/dfec1c0c670c15f7e4babad75cf7a1261870c374/scout/server/blueprints/variant/controllers.py#L296)

**How to prepare for test**:
- [ ] remove any previous Docker image for this repo: `docker image rm loqusdbapi_loqusdbapi`
- [ ] run `docker compose up`

### How to test:
- Send a get request to the server from another terminal: 
```curl -X GET "http://127.0.0.1:9000/cases"```

-  run `docker compose down`

### Expected outcome:
- The endpoint should return number of cases in database with SNVs and with SVs

### Review:
- [ ] Code approved by
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
