### PR TITLE
Rename "nr_cases" to "total" in returned variant info

### DIFF
--- a/loqusdbapi/main.py
+++ b/loqusdbapi/main.py
@@ -4,15 +4,14 @@ Small loqusdb api
 
 """
 
-from typing import Optional, List
-
-from fastapi import FastAPI, HTTPException, status, Depends
-from pydantic import BaseModel, BaseSettings
+from typing import List, Optional
 
 import loqusdb
+from fastapi import Depends, FastAPI, HTTPException, status
 from loqusdb.plugins.mongo import MongoAdapter
 from mongo_adapter import get_client
 from mongo_adapter.exceptions import Error as DB_Error
+from pydantic import BaseModel, BaseSettings
 
 
 class Settings(BaseSettings):
@@ -28,7 +27,7 @@ class BaseVariant(BaseModel):
     chrom: str
     observations: int
     families: List[str] = []
-    nr_cases: int
+    total: int
 
 
 class Variant(BaseVariant):
@@ -92,7 +91,7 @@ def read_variant(variant_id: str, db: MongoAdapter = Depends(database)):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=f"Variant {variant_id} not found"
         )
-    variant["nr_cases"] = db.nr_cases(snv_cases=True, sv_cases=False)
+    variant["total"] = db.nr_cases(snv_cases=True, sv_cases=False)
     return variant
 
 
@@ -116,7 +115,7 @@ def read_sv(
     )
     if not structural_variant:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Variant not found")
-    structural_variant["nr_cases"] = db.nr_cases(snv_cases=False, sv_cases=True)
+    structural_variant["total"] = db.nr_cases(snv_cases=False, sv_cases=True)
 
     return structural_variant
 


### PR DESCRIPTION
The variant info returned by the api differers from the info returned when using loqus exe for a key --> `nr_cases`, that should correspond to `total`

See an example of returned info from both:

**api**: {'chrom': '1', 'observations': 1, 'families': ['recessive_trio'], '**nr_cases**': 1, 'start': 879537, 'end': 879538, 'ref': 'T', 'alt': 'C', 'homozygote': 1, 'hemizygote': 0}

**exe**: {'alt': 'C', 'chrom': '1', 'end': 879538, 'families': ['recessive_trio'], 'hemizygote': 0, 'homozygote': 1, 'observations': 1, 'ref': 'T', 'start': 879537, '**total**': 1}

I could fix this Scout easily (see https://github.com/Clinical-Genomics/scout/pull/2349#issuecomment-831847848) but perhaps we are interested in both api and exe returning the same keys??


### Review:
- [x] Code approved by MM
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
