### PR TITLE
Use MongoDB 4.4.9 in docker-compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## []
+### Changed
+- Use MongoDB v. 4.4.9 in docker-compose file
+
 ## [1.0]
 ### Added
 - `/` endpoint is returning loqusdb version in use for this app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       MODULE_NAME: "loqusdbapi.main"
 
   mongo:
-    image: mongo
+    image: mongo:4.4.9
 
   restore:
     image: mongo:4.4.9

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     image: mongo
 
   restore:
-    image: mongo
+    image: mongo:4.4.9
     volumes:
       - ./dump:/var/dump
     links:


### PR DESCRIPTION
### This PR adds | fixes:
- Set the version of MongoDB to 4.4.9 in docker-compose file. FIx #14 

### How to test:
- docker-compose up
- Fetch a variant with the command: `curl -X GET "http://127.0.0.1:9000/variants/1_880086_T_C" -H "accept: application/json"`
- docker-compose down

### Expected outcome:
- [x] The API should return the variant

### Review:
- [ ] Code approved by
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
