### PR TITLE
Fix mongo adapter timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## []
+## [0.1.3]
+### Changed
+- Use mongo_adapter 0.3.3 in frozen requirements file
+
+
+## [0.1.2]
 ### Changed
 - Use MongoDB v. 4.4.9 in docker-compose file
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ h11==0.11.0
 httptools==0.1.2; (sys_platform != "win32" and sys_platform != "cygwin" and platform_python_implementation != "PyPy" and extra == "standard")
 humanfriendly==8.2
 loqusdb==2.5
-mongo-adapter==0.3
+mongo-adapter==0.3.3
 mongomock==3.18.0
 more-itertools==8.6.0
 numpy==1.19.4


### PR DESCRIPTION
### This PR adds | fixes:
- Update mongo-adapter to v0.3.3 to get longer default timeouts for mongo server selection

**How to prepare for test**:
- allow docker image to build
 
## How to test:
- deploy to cg-vm1 (cgvs stage) through systemd
- test a query to the api

### Expected outcome:
- [x] loqudbapi works, return questions and is likely more stable (see scout issues)

### Review:
- [x] Code approved by CR
- [x] Tests executed by DN
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
