### PR TITLE
Reintroduce total number of hits in Variant and SV Variant models

### DIFF
--- a/loqusdbapi/models.py
+++ b/loqusdbapi/models.py
@@ -61,6 +61,7 @@ class Variant(BaseVariant):
     alt: str
     homozygote: int
     hemizygote: int
+    total: int
 
 
 class StructuralVariant(BaseVariant):
@@ -73,6 +74,7 @@ class StructuralVariant(BaseVariant):
     pos_left: int
     pos_right: int
     pos_sum: int
+    total: int
 
 
 class Cases(BaseModel):


### PR DESCRIPTION
### This PR adds | fixes:
- Missing "total" key/values from "read_variant" and "read_sv" endpoints

### How to test:
- Launch the demo app (master branch) and run this query: `curl -X GET "http://127.0.0.1:8000/variants/1_880086_T_C"`-->It shouldn't return "total" key/value
- Repeat from this branch and the key/value should be there


### Review:
- [x] Code approved by DN
- [x] Tests executed by CR, DN

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
