### PR TITLE
Fix #28 - _id type

### DIFF
--- a/loqusdbapi/models.py
+++ b/loqusdbapi/models.py
@@ -3,6 +3,19 @@ from typing import Optional, List, Union, Any
 
 from pydantic import BaseModel, validator, Field
 
+from bson.objectid import ObjectId as BsonObjectId
+
+class PydanticObjectId(BsonObjectId):
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        if not isinstance(v, BsonObjectId):
+            raise TypeError('ObjectId required')
+        return str(v)
+
 class Individual(BaseModel):
     ind_id: str
     case_id: str
@@ -69,7 +82,7 @@ class Variant(BaseVariant):
 
 
 class StructuralVariant(BaseVariant):
-    id: Optional[Any] = Field(alias="_id")
+    id: Optional[BsonObjectId] = Field(alias="_id")
     end_chrom: str
     end_left: int
     end_right: int

--- a/loqusdbapi/models.py
+++ b/loqusdbapi/models.py
@@ -76,7 +76,7 @@ class Variant(BaseVariant):
 
 
 class StructuralVariant(BaseVariant):
-    id: BsonObjectId = Field(alias="_id")
+    id: Optional[PydanticObjectId] = Field(alias="_id")
     end_chrom: str
     end_left: int
     end_right: int

--- a/loqusdbapi/models.py
+++ b/loqusdbapi/models.py
@@ -65,7 +65,6 @@ class Variant(BaseVariant):
 
 
 class StructuralVariant(BaseVariant):
-    id: ObjectId = Field(alias="_id")
     end_chrom: str
     end_left: int
     end_right: int

--- a/loqusdbapi/models.py
+++ b/loqusdbapi/models.py
@@ -48,7 +48,7 @@ class Case(BaseModel):
 
 
 class BaseVariant(BaseModel):
-    id: str = Field(alias="_id")
+    id: Optional[Any] = Field(alias="_id")
     chrom: str
     observations: int
     families: List[str] = []
@@ -65,6 +65,7 @@ class Variant(BaseVariant):
 
 
 class StructuralVariant(BaseVariant):
+    id: ObjectId = Field(alias="_id")
     end_chrom: str
     end_left: int
     end_right: int

--- a/loqusdbapi/models.py
+++ b/loqusdbapi/models.py
@@ -48,13 +48,13 @@ class Case(BaseModel):
 
 
 class BaseVariant(BaseModel):
-    id: Optional[Any] = Field(alias="_id")
     chrom: str
     observations: int
     families: List[str] = []
 
 
 class Variant(BaseVariant):
+    id: str = Field(alias="_id")
     start: int
     end: int
     ref: str

--- a/loqusdbapi/models.py
+++ b/loqusdbapi/models.py
@@ -27,12 +27,6 @@ class Individual(BaseModel):
     profile: Optional[list] = []
     similar_samples: Optional[list] = []
 
-    @validator("id")
-    def id_to_str(cls, value):
-        if value:
-            return str(value)
-
-
 class Case(BaseModel):
     id: Optional[Any] = Field(alias="_id")
     case_id: str

--- a/loqusdbapi/models.py
+++ b/loqusdbapi/models.py
@@ -3,6 +3,7 @@ from typing import Optional, List, Union, Any
 
 from pydantic import BaseModel, validator, Field
 
+from bson
 
 class Individual(BaseModel):
     ind_id: str
@@ -14,6 +15,11 @@ class Individual(BaseModel):
     ind_index: Optional[int]
     profile: Optional[list] = []
     similar_samples: Optional[list] = []
+
+    @validator("id")
+    def id_to_str(cls, value):
+        if value:
+            return str(value)
 
 
 class Case(BaseModel):

--- a/loqusdbapi/models.py
+++ b/loqusdbapi/models.py
@@ -76,7 +76,7 @@ class Variant(BaseVariant):
 
 
 class StructuralVariant(BaseVariant):
-    id: Optional[BsonObjectId] = Field(alias="_id")
+    id: BsonObjectId = Field(alias="_id")
     end_chrom: str
     end_left: int
     end_right: int

--- a/loqusdbapi/models.py
+++ b/loqusdbapi/models.py
@@ -65,7 +65,7 @@ class Variant(BaseVariant):
 
 
 class StructuralVariant(BaseVariant):
-    id: str = Field(alias="_id")
+    id: Optional[Any] = Field(alias="_id")
     end_chrom: str
     end_left: int
     end_right: int
@@ -81,6 +81,10 @@ class StructuralVariant(BaseVariant):
     def id_to_str(cls, value):
         if value:
             return str(value)
+
+    class Config:
+        arbitrary_types_allowed = True
+        allow_population_by_field_name = True
 
 
 class Cases(BaseModel):

--- a/loqusdbapi/models.py
+++ b/loqusdbapi/models.py
@@ -88,6 +88,9 @@ class StructuralVariant(BaseVariant):
     pos_sum: int
     total: int
 
+    class Config:
+        arbitrary_types_allowed = True
+
 
 class Cases(BaseModel):
     nr_cases_snvs: Optional[int]

--- a/loqusdbapi/models.py
+++ b/loqusdbapi/models.py
@@ -3,18 +3,7 @@ from typing import Optional, List, Union, Any
 
 from pydantic import BaseModel, validator, Field
 
-from bson.objectid import ObjectId as BsonObjectId
-
-class PydanticObjectId(BsonObjectId):
-    @classmethod
-    def __get_validators__(cls):
-        yield cls.validate
-
-    @classmethod
-    def validate(cls, v):
-        if not isinstance(v, BsonObjectId):
-            raise TypeError('ObjectId required')
-        return str(v)
+from bson.objectid import ObjectId
 
 class Individual(BaseModel):
     ind_id: str
@@ -76,7 +65,7 @@ class Variant(BaseVariant):
 
 
 class StructuralVariant(BaseVariant):
-    id: Optional[PydanticObjectId] = Field(alias="_id")
+    id: str = Field(alias="_id")
     end_chrom: str
     end_left: int
     end_right: int
@@ -88,8 +77,10 @@ class StructuralVariant(BaseVariant):
     pos_sum: int
     total: int
 
-    class Config:
-        arbitrary_types_allowed = True
+    @validator("id")
+    def id_to_str(cls, value):
+        if value:
+            return str(value)
 
 
 class Cases(BaseModel):

--- a/loqusdbapi/models.py
+++ b/loqusdbapi/models.py
@@ -65,6 +65,7 @@ class Variant(BaseVariant):
 
 
 class StructuralVariant(BaseVariant):
+    id: Optional[Any] = Field(alias="_id")
     end_chrom: str
     end_left: int
     end_right: int

--- a/loqusdbapi/models.py
+++ b/loqusdbapi/models.py
@@ -3,8 +3,6 @@ from typing import Optional, List, Union, Any
 
 from pydantic import BaseModel, validator, Field
 
-from bson
-
 class Individual(BaseModel):
     ind_id: str
     case_id: str

--- a/tests/test_loqusdbapi.py
+++ b/tests/test_loqusdbapi.py
@@ -2,4 +2,4 @@ from loqusdbapi import __version__
 
 
 def test_version():
-    assert __version__ == '0.1.0'
+    assert __version__ == '0.1.5'


### PR DESCRIPTION
### This PR adds | fixes:
- issue retrieving SV vars from the API - See #28.

### How to test:
- test a local curl for a SV variant on cg-vm1
- check that scout-stage can reach SV variants

### Review:
- [ ] Code approved by
- [ ] Tests executed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
