### PR TITLE
Fix ports in docker-compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.1.7]
+- Fix docker-compose file to mirror changes in Dockerfile (serve app via gunicorn)
+
 ## [0.1.3]
 ### Changed
 - Use mongo_adapter 0.3.3 in frozen requirements file
-
 
 ## [0.1.2]
 ### Changed

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ etc, use the environmental variable `URI`.
 If only testing the app use the `docker-compose`-solution below.
 More information about setup should be fairly easy to understand by looking at `docker-compose.yml`.
 
+### poetry
+
+[Poetry][poetry] is the friendliest and most intuitive package manager for python.
+
+1. `poetry install`
+1. `uvicorn loqusdbapi.main:app --reload`
+
 ### pip
 To use with `pip` the easy solution is to install [micropipenv][micropipenv] and generate a requirements file:
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,6 @@ etc, use the environmental variable `URI`.
 If only testing the app use the `docker-compose`-solution below.
 More information about setup should be fairly easy to understand by looking at `docker-compose.yml`.
 
-### poetry
-
-[Poetry][poetry] is the friendliest and most intuitive package manager for python.
-
-1. `poetry install`
-1. `uvicorn loqusdbapi.main:app --reload`
-
 ### pip
 To use with `pip` the easy solution is to install [micropipenv][micropipenv] and generate a requirements file:
 
@@ -46,7 +39,7 @@ Head over to `http://127.0.0.1:8000/docs`
 ## Setup a test case with some data using docker compose
 
 1. `docker-compose up`
-1. Port `80` is mapped to `9000` in the docker compose file so go to `http://127.0.0.1:9000/docs`
+1. Port `8000` is mapped to `9000` in the docker compose file so go to `http://127.0.0.1:9000/docs`
 1. Request example to fetch a single-nucleotide (SNV) variant: `curl -X GET "http://127.0.0.1:9000/variants/1_880086_T_C"`
 1. Request example to fetch a structural variant (SV): `curl -X GET "http://127.0.0.1:9000/svs/?chrom=1&end_chrom=1&pos=7889972&end=7890026&sv_type=DEL"`
 1. Request example to get the number of cases with either SNVs or SVs present in database:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   loqusdbapi:
     build: .
     ports:
-      - 8000:8000
+      - 9000:8000
     links:
       - mongo:mongo
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   loqusdbapi:
     build: .
     ports:
-      - 9000:80
+      - 8000:8000
     links:
       - mongo:mongo
     environment:


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #32 

### How to test:
 1. From master branch, run `docker-compose up`
2. Try to run a query: 
`curl -X GET "http://127.0.0.1:9000/svs/?chrom=1&end_chrom=1&pos=7889972&end=7890026&sv_type=DEL`
3. run `docker-compose down`
4. Switch to this branch and repeat 1 and 2

### Expected outcome:
- [ ] Observations of variant should be returned

### Review:
- [ ] Code approved by
- [ ] Tests executed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
