### PR TITLE
Fix docker release tag naming to make deploying easier

### DIFF
--- a/.github/workflows/dockerhub_push_release.yml
+++ b/.github/workflows/dockerhub_push_release.yml
@@ -31,4 +31,4 @@ jobs:
          context: ./
          file: ./Dockerfile
          push: true
-         tags: "clinicalgenomics/loqusdbapi:${{github.event.release.tag_name}}, clinicalgenomics/loqusdbapi:latest, clinicalgenomics/loqusdbapi:master"
+         tags: "clinicalgenomics/loqusdbapi:v${{github.event.release.tag_name}}, clinicalgenomics/loqusdbapi:latest, clinicalgenomics/loqusdbapi:master"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.2]
-### Changed
-- Unfreeze pymongo to support connections to new MongoDB software
-
-## [0.1.8]
+## [0.1.10]
 ### Fixed
-- Fix PyYaml installation error
-- Unfreeze also loqusdb dependency
+-  Introduce a "v" char before the numeric version tag that is pushed to Docker Hub prod when a new release is created
+
+## [0.1.9]
+### changed
+- Unfreeze pymongo to support connections to new MongoDB software
 
 ## [0.1.7]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### changed
 - Unfreeze pymongo to support connections to new MongoDB software
 
+## [0.1.8]
+### Fixed
+- Fix PyYaml installation error
+
 ## [0.1.7]
 ### Fixed
 - Fix docker-compose file to mirror changes in Dockerfile (serve app via gunicorn)


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #40 

### How to test:
- Merge and make sure the release tag on Docker hub is v0.1.10 instead of 0.1.10


### Review:
- [x] Code approved by DNIL
- [ ] Tests executed by GitHub action

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
