### PR TITLE
Fix gunicorn workers booting by modifying Dockerfile to use python bullseye

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.1.12]
+### Fixed
+-  Modified Docker files to use python:3.9-slim-bullseye to prevent gunicorn workers booting error
+
 ## [0.1.11]
 ### Fixed
 -  For compliance with latest MongoDB versions update loqusdb version to >=2.7.3 in requirements

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.9-slim-bullseye
 
 ENV GUNICORN_WORKERS=1
 ENV GUNICORN_THREADS=1


### PR DESCRIPTION
Fix #41, fix #44 

### How to test:
- Deploy on cg-vm1 stage and see

### Expected outcome:
- [x] Hope it works!

### Review:
- [x] Code approved by DN
- [x] Tests executed by DN 

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
