### PR TITLE
Fix MT variants query for genome build 38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.1.13]
+### Fixed
+- Fix chromosome name to "M" when user runs queries for "MT" variants on an database instance in build 38
+
 ## [0.1.12]
 ### Fixed
 -  Modified Docker files to use python:3.9-slim-bullseye to prevent gunicorn workers booting error

--- a/loqusdbapi/main.py
+++ b/loqusdbapi/main.py
@@ -47,16 +47,16 @@ def read_root():
         "loqusdb_version": loqusdb.__version__,
     }
 
-def get_mt_chromosome(mt_chrom: Optional[str]) -> Optional[str]:
+def set_chromosome(chrom: Optional[str]) -> Optional[str]:
     """Getting right MT chromosome, according to the query and the genome build used in the app."""
-    if settings.genome_build == "GRCh38" and mt_chrom == "MT":
+    if settings.genome_build == "GRCh38" and chrom == "MT":
         return "M"
-    return mt_chrom
+    return chrom
 
 @app.get("/variants/{variant_id}", response_model=Variant)
 def read_variant(variant_id: str, db: MongoAdapter = Depends(database)):
     variant_coordinates : List[str] = variant_id.split("_")
-    variant_coordinates[0] : str = get_mt_chromosome(variant_coordinates[0])
+    variant_coordinates[0] : str = set_chromosome(variant_coordinates[0])
     variant = db.get_variant({"_id": "_".join(variant_coordinates)})
     if not variant:
         raise HTTPException(
@@ -77,8 +77,8 @@ def read_sv(
 ):
     structural_variant = db.get_structural_variant(
         {
-            "chrom": get_mt_chromosome(chrom),
-            "end_chrom": get_mt_chromosome(end_chrom) or get_mt_chromosome(chrom),
+            "chrom": set_chromosome(chrom),
+            "end_chrom": set_chromosome(end_chrom) or set_chromosome(chrom),
             "sv_type": sv_type,
             "pos": pos,
             "end": end,

--- a/loqusdbapi/main.py
+++ b/loqusdbapi/main.py
@@ -6,7 +6,7 @@ Small loqusdb api
 import logging
 import loqusdb
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List
 
 from fastapi import Depends, FastAPI, HTTPException, status
 from fastapi.encoders import jsonable_encoder
@@ -40,9 +40,6 @@ def database(uri: str = None, db_name: str = None) -> MongoAdapter:
 
     return MongoAdapter(client, db_name=db_name)
 
-def mt_chrom_baseline():
-
-
 @app.get("/")
 def read_root():
     return {
@@ -50,7 +47,7 @@ def read_root():
         "loqusdb_version": loqusdb.__version__,
     }
 
-def get_mt_chromosome(mt_chrom: str) -> str:
+def get_mt_chromosome(mt_chrom: Optional[str]) -> Optional[str]:
     """Getting right MT chromosome, according to the query and the genome build used in the app."""
     if settings.genome_build == "GRCh38" and mt_chrom == "MT":
         return "M"


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #47

**How to prepare for test**:
- [ ] Add one MT variant in a loqusdb instance with genome build 38

### How to test:
- [ ] Run queries, possibly from Scout (variants in genome build 38)

### Expected outcome:
- [ ] Occurrences for MT variants should be returned

### Review:
- [ ] Code approved by
- [ ] Tests executed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
