### PR TITLE
Update setuptools to address package_index vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.1.14]
+## [0.1.13]
 ### Changed
 - Updated issue template
 ### Fixed
 - Update to setuptools >= v.70 to address a security issue in the package_index module
-
-## [0.1.13]
-### Fixed
-- Fix chromosome name to "M" when user runs queries for "MT" variants on an database instance in build 38
 
 ## [0.1.12]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.1.14]
+### Fixed
+- Update to setuptools >= v.70 to address a security issue in the `package_index` module
+
 ## [0.1.13]
 ### Changed
 - Updated issue template
-### Fixed
-- Update to setuptools >= v.70 to address a security issue in the `package_index` module
 
 ## [0.1.12]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Updated issue template
 ### Fixed
-- Update to setuptools >= v.70 to address a security issue in the package_index module
+- Update to setuptools >= v.70 to address a security issue in the `package_index` module
 
 ## [0.1.12]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.1.14]
+### Changed
+- Updated issue template
+### Fixed
+- Update to setuptools >= v.70 to address a security issue in the package_index module
+
+## [0.1.13]
+### Fixed
+- Fix chromosome name to "M" when user runs queries for "MT" variants on an database instance in build 38
+
 ## [0.1.12]
 ### Fixed
 -  Modified Docker files to use python:3.9-slim-bullseye to prevent gunicorn workers booting error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Update to setuptools >= v.70 to address a security issue in the `package_index` module
 
 ## [0.1.13]
-### Changed
+### Fixed
 - Updated issue template
 
 ## [0.1.12]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ numpy==1.21.4
 coloredlogs==14.0
 pyyaml>=5.4.1
 vcftoolbox==1.5
-setuptools
+setuptools>=70.0.0
 fastapi==0.61.2
 pydantic==1.7.2
 starlette==0.13.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytest==5.4.3
-loqusdb>=2.7.3
+loqusdb>=2.7.7
 cyvcf2==0.30.12
 mongomock
 click==7.1.2


### PR DESCRIPTION
## Description
- Closes #50 

### Fixed
- Docker image should build without errors and pushed to Docker Hub (doesn't work unless we update setuptools in [loqusdb repo first](https://github.com/Clinical-Genomics/loqusdb/pull/133))


### How to test
- [x] Make sure the Docker image builds and gets pushed to Docker Hub

## Review

- [x] Tests executed by GitHub actions
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
